### PR TITLE
Fix issues #1 #2 #3 #4 #6 and add CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish on version tags pushed to main
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'hhhwwwuuu/BackTranslation'
+    permissions:
+      contents: write  # needed to create GitHub Release
 
     steps:
       - uses: actions/checkout@v4
@@ -56,3 +58,11 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/* \
+            --title "Release ${{ github.ref_name }}" \
+            --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install "googletrans==4.0.0rc1" httpcore nltk pytest pytest-mock
+
+      - name: Run tests
+        run: pytest tests/ -v
+
+  publish:
+    name: Publish to PyPI
+    needs: test
+    runs-on: ubuntu-latest
+    # Only publish on version tags pushed to main
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'hhhwwwuuu/BackTranslation'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+dist/
+build/
+*.egg-info/
+.env

--- a/BackTranslation/translated.py
+++ b/BackTranslation/translated.py
@@ -16,7 +16,9 @@ class Translated(object):
 
 
     def __unicode__(self):
-        if len(self.result_text) > 30 :
+        if len(self.result_text.split(' ')) > 30:
             show_text = ' '.join(self.result_text.split(' ')[:30])
             show_text += '...'
-        return u'Trabslated(src={src}, tmp={tmp}, result_text={text})'.format(src=self.src, tmp=self.tmp, text = self.result_text)
+        else:
+            show_text = self.result_text
+        return u'Translated(src={src}, tmp={tmp}, result_text={text})'.format(src=self.src, tmp=self.tmp, text=show_text)

--- a/BackTranslation/translation.py
+++ b/BackTranslation/translation.py
@@ -49,24 +49,44 @@ class BackTranslation(object):
             raise ValueError("'{}': INVALID transited language.".format(tmp))
 
         if src == tmp:
-            raise ValueError("Transited language ({tmp}) should different from srouce language ({src}).".format(
-                tmp=self.langCodes[tmp], src=self.langCodes[src]))
+            raise ValueError("Transited language ({tmp}) should different from source language ({src}).".format(
+                tmp=tmp, src=src))
 
         # check the length of text
         if len(text) > self.MAX_LENGTH:
             original_sentences = self._split_segement(sent_tokenize(text))
 
-            t_text = self.translator.translate(original_sentences, src=src, dest=tmp)
+            try:
+                t_text = self.translator.translate(original_sentences, src=src, dest=tmp)
+            except httpcore.ConnectTimeout:
+                raise httpcore.ConnectTimeout("Connection timed out. If you are blocked by Google, try using the 'proxies' parameter or a different 'url'.")
+            except Exception as e:
+                raise Exception("Translation failed (try increasing the 'sleeping' parameter): {}".format(e))
             tran_text = ' '.join([t.text for t in t_text])
             time.sleep(sleeping)
-            r_text = self.translator.translate([t.text for t in t_text], src=tmp, dest=src)
+            try:
+                r_text = self.translator.translate([t.text for t in t_text], src=tmp, dest=src)
+            except httpcore.ConnectTimeout:
+                raise httpcore.ConnectTimeout("Connection timed out. If you are blocked by Google, try using the 'proxies' parameter or a different 'url'.")
+            except Exception as e:
+                raise Exception("Back-translation failed (try increasing the 'sleeping' parameter): {}".format(e))
             back_text = ' '.join([r.text for r in r_text])
             back_text.rstrip()
         else:
-            mid_text = self.translator.translate(text, src=src, dest=tmp)
+            try:
+                mid_text = self.translator.translate(text, src=src, dest=tmp)
+            except httpcore.ConnectTimeout:
+                raise httpcore.ConnectTimeout("Connection timed out. If you are blocked by Google, try using the 'proxies' parameter or a different 'url'.")
+            except Exception as e:
+                raise Exception("Translation failed (try increasing the 'sleeping' parameter): {}".format(e))
             tran_text = mid_text.text
             time.sleep(sleeping)  # Sleep between translation
-            result_text = self.translator.translate(tran_text, src=tmp, dest=src)
+            try:
+                result_text = self.translator.translate(tran_text, src=tmp, dest=src)
+            except httpcore.ConnectTimeout:
+                raise httpcore.ConnectTimeout("Connection timed out. If you are blocked by Google, try using the 'proxies' parameter or a different 'url'.")
+            except Exception as e:
+                raise Exception("Back-translation failed (try increasing the 'sleeping' parameter): {}".format(e))
             back_text = result_text.text
         result = Translated(src_lang=src, tmp_lang=tmp, text=text, trans_text=tran_text, back_text=back_text)
         return result

--- a/BackTranslation/translation_Baidu.py
+++ b/BackTranslation/translation_Baidu.py
@@ -3,6 +3,7 @@ import hashlib
 import urllib
 import random
 import json
+import time
 
 import nltk
 from nltk.tokenize import sent_tokenize
@@ -30,7 +31,7 @@ class BackTranslation_Baidu(object):
         self.httpClient = http.client.HTTPConnection('api.fanyi.baidu.com')
         self.queryURL = '/api/trans/vip/translate'
 
-    def translate(self, text, src='auto', tmp=None):
+    def translate(self, text, src='auto', tmp=None, sleeping=1):
         if src == 'auto':
             src = self._get_srcLang(self._sendRequest(text, src, 'en'))
 
@@ -57,14 +58,17 @@ class BackTranslation_Baidu(object):
                 # language A --> language B
                 mid = self._get_translatedText(self._sendRequest(sentence, src, tmp))
                 tran_text.append(mid)
+                time.sleep(sleeping)
 
                 # language B --> language A
                 back_text.append(self._get_translatedText(self._sendRequest(mid, tmp, src)))
+                time.sleep(sleeping)
             tran_text = ' '.join(tran_text)
             back_text = ' '.join(back_text)
         else:
             tran_text = self._get_translatedText(self._sendRequest(text, src, tmp))
-            back_text = self._get_translatedText(self._sendRequest(text, tmp, src))
+            time.sleep(sleeping)
+            back_text = self._get_translatedText(self._sendRequest(tran_text, tmp, src))
         result = Translated(src_lang=src, tmp_lang=tmp, text=text, trans_text=tran_text, back_text=back_text)
         return result
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Parameters:
 * **text**: required. Original text that need to do back translation.
 * **src**: option. Source language code of original text. If this parameter is None, the method will detect the language of text automatically. (Default: None)
 * **tmp**: option. Middle language code. If this parameter is None, the method will pick one of two languages which is different from src.
-* **sleeping**: option. It is a timer to limite the speed of back-translation to avoid the limitation of Google.  (Default: 0)
+* **sleeping**: option. It is a timer to limit the speed of back-translation to avoid Google rate limits (HTTP 429). Increase this value if you encounter errors after many translations. (Default: 0)
 
 Return parameter: object _Translated_.
 
@@ -41,13 +41,32 @@ Attributes:
 
 ```python
 from BackTranslation import BackTranslation
+trans = BackTranslation()
+result = trans.translate('hello', src='en', tmp='zh-cn')
+print(result.result_text)
+# 'Hello there'
+```
+
+Complete example with auto language detection:
+```python
+from BackTranslation import BackTranslation
+trans = BackTranslation()
+result = trans.translate('Anh ấy đã chữa khỏi cảm cúm bằng aspirin.')
+print(result.src)         # 'vi'
+print(result.tmp)         # 'en'
+print(result.tran_text)   # intermediate translation
+print(result.result_text) # back-translated result
+```
+
+If Google blocks your IP, you can provide alternative service URLs or a proxy:
+```python
+from BackTranslation import BackTranslation
 trans = BackTranslation(url=[
       'translate.google.com',
       'translate.google.co.kr',
     ], proxies={'http': '127.0.0.1:1234', 'http://host.name': '127.0.0.1:4012'})
-result = trans.translate('hello', src='en', tmp = 'zh-cn')
+result = trans.translate('hello', src='en', tmp='zh-cn')
 print(result.result_text)
-# 'Hello there'
 ```
 
 
@@ -69,12 +88,14 @@ trans.searchLanguage('Chinese')
 To use this stable translation, you are required to register in [Baidu Translation API]((http://api.fanyi.baidu.com/)) for getting your own appID.
 It supports 2 million chacters per day for free.
 _Note: Currently, they only support Chinese phone number to register the accout._
+* **sleeping**: option. Baidu standard API allows only 1 request per second (QPS limit). Set `sleeping=1` (default) to stay within the limit. Increase if you encounter errors. (Default: 1)
+
 ````python
 from BackTranslation import BackTranslation_Baidu
 trans = BackTranslation_Baidu(appid='YOUR APPID', secretKey='YOUR SECRETKEY')
 result = trans.translate('hello', src='auto', tmp='zh')
-print(result.result_text)
-# 'hello'
+print(result.tran_text)   # intermediate translation
+print(result.result_text) # back-translated result
 trans.closeHTTP()
 ```` 
 #### Seach language code

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from distutils.core import setup
 import setuptools
+import os
+
+# In CI, version is driven by the git tag (e.g. v0.3.2 -> 0.3.2).
+# Locally falls back to 0.0.0.dev so the package can still be installed.
+version = os.environ.get('GITHUB_REF_NAME', '0.0.0.dev').lstrip('v')
 
 setup(
     name = 'BackTranslation',
-    version = "0.3.1",
+    version = version,
     author = "Zhiqiang Wu",
     author_email = "wzq0515@gmail.com",
     license = "MIT",

--- a/tests/test_translated.py
+++ b/tests/test_translated.py
@@ -1,0 +1,39 @@
+import pytest
+from BackTranslation.translated import Translated
+
+
+def make_result(back_text):
+    return Translated(src_lang='en', tmp_lang='zh-cn', text='hello', trans_text='你好', back_text=back_text)
+
+
+def test_attributes():
+    r = make_result('hello there')
+    assert r.source_text == 'hello'
+    assert r.src == 'en'
+    assert r.tmp == 'zh-cn'
+    assert r.tran_text == '你好'
+    assert r.result_text == 'hello there'
+
+
+def test_str_short():
+    r = make_result('hello there')
+    s = str(r)
+    assert 'hello there' in s
+    assert 'Translated' in s
+    assert '...' not in s
+
+
+def test_str_long():
+    long_text = ' '.join(['word'] * 50)
+    r = make_result(long_text)
+    s = str(r)
+    assert '...' in s
+    # Should only show first 30 words
+    assert s.count('word') == 30
+
+
+def test_str_exactly_30_words():
+    text = ' '.join(['word'] * 30)
+    r = make_result(text)
+    s = str(r)
+    assert '...' not in s

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,148 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from BackTranslation.translation import BackTranslation
+import httpcore
+
+
+def _make_translate_result(text):
+    m = MagicMock()
+    m.text = text
+    return m
+
+
+@pytest.fixture
+def trans():
+    with patch('BackTranslation.translation.Translator') as MockTranslator:
+        instance = MockTranslator.return_value
+        instance.translate.side_effect = lambda text, src, dest: (
+            _make_translate_result('你好') if dest != 'en' else _make_translate_result('Hello there')
+        )
+        instance.detect.return_value = MagicMock(lang='en')
+        yield BackTranslation.__new__(BackTranslation), instance, MockTranslator
+
+
+def _build_trans(mock_translate_fn=None):
+    with patch('BackTranslation.translation.Translator') as MockTranslator:
+        instance = MockTranslator.return_value
+        if mock_translate_fn:
+            instance.translate.side_effect = mock_translate_fn
+        instance.detect.return_value = MagicMock(lang='en')
+        t = BackTranslation()
+        t.translator = instance
+        return t, instance
+
+
+def test_basic_translation():
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = [
+        _make_translate_result('你好'),
+        _make_translate_result('Hello there'),
+    ]
+    result = trans.translate('hello', src='en', tmp='zh-cn')
+    assert result.src == 'en'
+    assert result.tmp == 'zh-cn'
+    assert result.source_text == 'hello'
+    assert result.tran_text == '你好'
+    assert result.result_text == 'Hello there'
+
+
+def test_auto_detect_src():
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = [
+        _make_translate_result('你好'),
+        _make_translate_result('Hello there'),
+    ]
+    result = trans.translate('hello', tmp='zh-cn')
+    assert result.src == 'en'
+
+
+def test_default_tmp_when_src_en():
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = [
+        _make_translate_result('你好'),
+        _make_translate_result('Hello there'),
+    ]
+    result = trans.translate('hello', src='en')
+    assert result.tmp == 'zh-cn'
+
+
+def test_default_tmp_when_src_not_en():
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = [
+        _make_translate_result('hello'),
+        _make_translate_result('你好'),
+    ]
+    result = trans.translate('你好', src='zh-cn')
+    assert result.tmp == 'en'
+
+
+def test_invalid_src_raises():
+    trans, _ = _build_trans()
+    with pytest.raises(ValueError, match='INVALID source language'):
+        trans.translate('hello', src='xx')
+
+
+def test_invalid_tmp_raises():
+    trans, _ = _build_trans()
+    with pytest.raises(ValueError, match='INVALID transited language'):
+        trans.translate('hello', src='en', tmp='xx')
+
+
+def test_same_src_tmp_raises():
+    trans, _ = _build_trans()
+    with pytest.raises(ValueError, match='should different'):
+        trans.translate('hello', src='en', tmp='en')
+
+
+def test_sleeping_is_called(mocker):
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = [
+        _make_translate_result('你好'),
+        _make_translate_result('Hello there'),
+    ]
+    mock_sleep = mocker.patch('BackTranslation.translation.time.sleep')
+    trans.translate('hello', src='en', tmp='zh-cn', sleeping=2)
+    mock_sleep.assert_called_once_with(2)
+
+
+def test_connect_timeout_raises_friendly_message():
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = httpcore.ConnectTimeout()
+    with pytest.raises(httpcore.ConnectTimeout, match='proxies'):
+        trans.translate('hello', src='en', tmp='zh-cn')
+
+
+def test_general_exception_raises_with_hint():
+    trans, mock_translator = _build_trans()
+    mock_translator.translate.side_effect = Exception('some googletrans error')
+    with pytest.raises(Exception, match="sleeping"):
+        trans.translate('hello', src='en', tmp='zh-cn')
+
+
+def test_search_language():
+    trans, _ = _build_trans()
+    result = trans.searchLanguage('Chinese')
+    assert 'zh-cn' in result.values()
+
+
+def test_search_language_not_found():
+    trans, _ = _build_trans()
+    with pytest.raises(ValueError):
+        trans.searchLanguage('notareallanguage')
+
+
+def test_long_text_split(mocker):
+    trans, mock_translator = _build_trans()
+    long_text = 'Hello world. ' * 500
+
+    tran_mock = _make_translate_result('你好')
+    back_mock = _make_translate_result('Hello there')
+    mock_translator.translate.side_effect = [
+        [tran_mock],       # first call: list of sentences → list of results
+        [back_mock],       # second call: back-translate list
+    ]
+    mocker.patch('BackTranslation.translation.sent_tokenize', return_value=['Hello world. ' * 250, 'Hello world. ' * 250])
+    mock_sleep = mocker.patch('BackTranslation.translation.time.sleep')
+    result = trans.translate(long_text, src='en', tmp='zh-cn')
+    assert result.src == 'en'
+    assert mock_sleep.called

--- a/tests/test_translation_baidu.py
+++ b/tests/test_translation_baidu.py
@@ -1,0 +1,115 @@
+import pytest
+import json
+from unittest.mock import MagicMock, patch, call
+from BackTranslation.translation_Baidu import BackTranslation_Baidu
+
+
+def _mock_response(src_lang, translated_text):
+    return {
+        'from': src_lang,
+        'to': 'en',
+        'trans_result': [{'dst': translated_text, 'src': 'original'}]
+    }
+
+
+@pytest.fixture
+def trans():
+    with patch('BackTranslation.translation_Baidu.http.client.HTTPConnection'):
+        t = BackTranslation_Baidu(appid='test_appid', secretKey='test_secret')
+        t._sendRequest = MagicMock()
+        return t
+
+
+def test_basic_translation(trans):
+    trans._sendRequest.side_effect = [
+        _mock_response('en', '你好'),
+        _mock_response('zh', 'Hello there'),
+    ]
+    result = trans.translate('hello', src='en', tmp='zh')
+    assert result.src == 'en'
+    assert result.tmp == 'zh'
+    assert result.tran_text == '你好'
+    assert result.result_text == 'Hello there'
+
+
+def test_back_translation_uses_tran_text_not_original(trans):
+    """Issue #6: back-translation must use tran_text, not the original text."""
+    calls = []
+
+    def side_effect(text, src, tmp):
+        calls.append((text, src, tmp))
+        if src == 'en':
+            return _mock_response('en', '你好')
+        return _mock_response('zh', 'Hello there')
+
+    trans._sendRequest.side_effect = side_effect
+    trans.translate('hello', src='en', tmp='zh')
+
+    assert calls[0] == ('hello', 'en', 'zh')
+    assert calls[1][0] == '你好', "Back-translation must use intermediate text, not original"
+
+
+def test_auto_detect_src(trans):
+    trans._sendRequest.side_effect = [
+        _mock_response('en', 'detected'),
+        _mock_response('en', '你好'),
+        _mock_response('zh', 'Hello there'),
+    ]
+    result = trans.translate('hello', src='auto', tmp='zh')
+    assert result.src == 'en'
+
+
+def test_default_tmp_when_src_en(trans):
+    trans._sendRequest.side_effect = [
+        _mock_response('en', '你好'),
+        _mock_response('zh', 'Hello there'),
+    ]
+    result = trans.translate('hello', src='en')
+    assert result.tmp == 'zh'
+
+
+def test_default_tmp_when_src_not_en(trans):
+    trans._sendRequest.side_effect = [
+        _mock_response('zh', 'hello'),
+        _mock_response('en', '你好'),
+    ]
+    result = trans.translate('你好', src='zh')
+    assert result.tmp == 'en'
+
+
+def test_same_src_tmp_raises(trans):
+    with pytest.raises(ValueError, match='should different'):
+        trans.translate('hello', src='en', tmp='en')
+
+
+def test_invalid_appid():
+    with patch('BackTranslation.translation_Baidu.http.client.HTTPConnection'):
+        with pytest.raises(ValueError, match='INVALID appid'):
+            BackTranslation_Baidu(appid='', secretKey='secret')
+
+
+def test_invalid_secretkey():
+    with patch('BackTranslation.translation_Baidu.http.client.HTTPConnection'):
+        with pytest.raises(ValueError, match='INVALID secretKey'):
+            BackTranslation_Baidu(appid='appid', secretKey='')
+
+
+def test_sleeping_is_called(trans, mocker):
+    """Issue #6: sleeping parameter must throttle requests to respect Baidu 1 QPS."""
+    trans._sendRequest.side_effect = [
+        _mock_response('en', '你好'),
+        _mock_response('zh', 'Hello there'),
+    ]
+    mock_sleep = mocker.patch('BackTranslation.translation_Baidu.time.sleep')
+    trans.translate('hello', src='en', tmp='zh', sleeping=1)
+    mock_sleep.assert_called_with(1)
+
+
+def test_default_sleeping_is_one(trans, mocker):
+    trans._sendRequest.side_effect = [
+        _mock_response('en', '你好'),
+        _mock_response('zh', 'Hello there'),
+    ]
+    mock_sleep = mocker.patch('BackTranslation.translation_Baidu.time.sleep')
+    trans.translate('hello', src='en', tmp='zh')
+    mock_sleep.assert_called_with(1)


### PR DESCRIPTION
## Summary

- Closes #1: wrap Google Translate calls with `try/except`; `ConnectTimeout` now shows a friendly hint about `proxies` and `sleeping` parameter
- Closes #2: README now has a dedicated proxy example section so users understand when proxies are needed
- Closes #3: `ConnectTimeout` raises with actionable message pointing to `proxies`/`url`; README primary example no longer includes proxy config that misled users
- Closes #4: README now includes a complete minimal example with auto language detection (including Vietnamese sentence as requested)
- Closes #6: back-translation in `BackTranslation_Baidu` now correctly passes `tran_text` (not original `text`) to `_sendRequest`; adds `sleeping=1` default to respect Baidu 1 QPS limit

## Additional fixes

- `translated.py`: typo `Trabslated` -> `Translated`; missing `else` branch; truncation now based on word count (> 30 words) instead of character count
- `translation.py`: `KeyError` when `src == tmp` due to wrong use of `langCodes`

## Added

- `tests/`: 27 pytest test cases covering all modules with mocked network calls
- `.github/workflows/ci.yml`: run tests on every push/PR (Python 3.9-3.12); auto-publish to PyPI and create GitHub Release on version tags
- `.gitignore`
